### PR TITLE
add overlay for nerc-shift-1 cluster

### DIFF
--- a/k8s/overlays/nerc-shift-1/kustomization.yaml
+++ b/k8s/overlays/nerc-shift-1/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+namespace: default
+resources:
+  - ../../base
+  - secrets
+  - pvc.yaml
+
+patchesStrategicMerge:
+  - patches/patch-vault-backup-cron.yaml

--- a/k8s/overlays/nerc-shift-1/patches/patch-vault-backup-cron.yaml
+++ b/k8s/overlays/nerc-shift-1/patches/patch-vault-backup-cron.yaml
@@ -1,0 +1,62 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: vault-backup
+  namespace: vault
+spec:
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: vault-backup
+              env:
+                - name: VAULT_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: vault-unseal-keys
+                      key: vault-root
+                - name: VAULT_ADDR
+                  $patch: replace
+                  valueFrom:
+                    secretKeyRef:
+                      name: vault-backup
+                      key: vault_addr
+                - name: S3_ENDPOINT
+                  $patch: replace
+                  valueFrom:
+                    secretKeyRef:
+                      name: vault-backup
+                      key: s3_endpoint
+                - name: S3_BUCKET_URI
+                  $patch: replace
+                  valueFrom:
+                    secretKeyRef:
+                      name: vault-backup
+                      key: s3_bucket_uri
+                - name: GPG_PUB_KEY
+                  $patch: replace
+                  valueFrom:
+                    secretKeyRef:
+                      name: vault-backup
+                      key: gpg_pub_key
+                - name: GPG_RECIPIENT
+                  $patch: replace
+                  valueFrom:
+                    secretKeyRef:
+                      name: vault-backup
+                      key: gpg_recipient
+                - name: BACKUP_ROTATE
+                  $patch: replace
+                  valueFrom:
+                    secretKeyRef:
+                      name: vault-backup
+                      key: backup_rotate
+          volumes:
+            - name: vault-backup-cacert
+              secret:
+                secretName: vault-tls
+                items:
+                  - key: 'ca.crt'
+                    path: 'vault_ca.crt'

--- a/k8s/overlays/nerc-shift-1/pvc.yaml
+++ b/k8s/overlays/nerc-shift-1/pvc.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: vault-backup
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/k8s/overlays/nerc-shift-1/secrets/kustomization.yaml
+++ b/k8s/overlays/nerc-shift-1/secrets/kustomization.yaml
@@ -1,0 +1,3 @@
+---
+resources:
+  - vault-backup.yaml

--- a/k8s/overlays/nerc-shift-1/secrets/vault-backup.yaml
+++ b/k8s/overlays/nerc-shift-1/secrets/vault-backup.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: external-secrets.io/v1alpha1
+kind: ExternalSecret
+metadata:
+  name: vault-backup
+spec:
+  refreshInterval: "15s"
+  secretStoreRef:
+    name: vault-backend
+    kind: ClusterSecretStore
+  target:
+    name: vault-backup
+  data:
+    - secretKey: aws_credentials
+      remoteRef:
+        key: accounts/holecs
+        property: awscli_credentials
+    - secretKey: backup_rotate
+      remoteRef:
+        key: vault-backup/config
+        property: backup_rotate
+    - secretKey: vault_addr
+      remoteRef:
+        key: vault-backup/config
+        property: vault_addr
+    - secretKey: s3_endpoint
+      remoteRef:
+        key: vault-backup/config
+        property: s3_endpoint
+    - secretKey: s3_bucket_uri
+      remoteRef:
+        key: vault-backup/config
+        property: s3_bucket_uri
+    - secretKey: gpg_recipient
+      remoteRef:
+        key: vault-backup/config
+        property: gpg_recipient
+    - secretKey: gpg_pub_key
+      remoteRef:
+        key: vault-backup/config
+        property: gpg_pub_key


### PR DESCRIPTION
This adds the setup and config for vault-backup on the `nerc-shift-1` cluster. Uses kustomize to patch the `CronJob` manifest to read all script env vars from an external-secret.